### PR TITLE
Allow to specify workdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This is a GitHub Action written to streamline the Ruby gem publication process. 
 
 `RELEASE_COMMAND` - By default, this will invoke `rake release` to build and publish the gem to Rubygems. Set this environment variable if you have a custom release command to be invoked.
 
+`WORKDIR` - Sets the workdir where bundle and the release will be run
+
 `GIT_EMAIL`/`GIT_NAME` - A git identity you wish the tags to by published by.
 
 # Example

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,9 @@ else
   git config user.email "${GIT_EMAIL:-automated@example.com}"
   git config user.name "${GIT_NAME:-Automated Release}"
 
+  work_directory="${WORKDIR:-.}"
+  cd $work_directory
+
   echo "Installing dependencies..."
   gem update bundler
   bundle install


### PR DESCRIPTION
This is helpful if a repo contains ruby project in a sub-folder.

Inspired by https://github.com/cadwallion/publish-rubygems-action/pull/17