### PR TITLE
Add output to track publish result

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,4 +37,6 @@ else
   echo "Running gem release task..."
   release_command="${RELEASE_COMMAND:-rake release}"
   exec $release_command
+
+  echo "new_version_published=true" >> $GITHUB_OUTPUT
 fi


### PR DESCRIPTION
We could use this output in other steps to know that publication flow was complete and successful.